### PR TITLE
Extract main words entered with Japanese IME

### DIFF
--- a/lib/Spreadsheet/XLSX.pm
+++ b/lib/Spreadsheet/XLSX.pm
@@ -43,6 +43,7 @@ sub new {
 		my $mstr = $member_shared_strings->contents; 
 		$mstr =~ s/<t\/>/<t><\/t>/gsm;  # this handles an empty t tag in the xml <t/>
 		foreach my $si ($mstr =~ /<si.*?>(.*?)<\/si/gsm) {
+            $si =~ s/<rPh[^>]*>.*?<\/rPh>//gsm; # Extract main words entered with Japanese IME
 			my $str;
 			foreach my $t ($si =~ /<t.*?>(.*?)<\/t/gsm) {
 				$t = $converter -> convert ($t) if $converter;


### PR DESCRIPTION
The original code cannot handle Japanese words entered in the IME.
Added a main words extraction code.